### PR TITLE
Use a map with file modified times instead of fixed system time

### DIFF
--- a/src/ns_tracker/core.clj
+++ b/src/ns_tracker/core.clj
@@ -14,11 +14,21 @@
   {:pre [(every? file? dirs)]}
   (mapcat find-clojure-sources-in-dir dirs))
 
-(defn- newer-sources [dirs timestamp]
-  (filter #(> (.lastModified %) timestamp) (find-sources dirs)))
+(defn- current-timestamp-map
+  "Get the current modified timestamp map for all sources"
+  [dirs]
+  (into {} (map (fn [f] {f (.lastModified f)}) (find-sources dirs))))
 
-(defn- newer-namespace-decls [dirs timestamp]
-  (remove nil? (map read-file-ns-decl (newer-sources dirs timestamp))))
+(defn- modified?
+  "Compare a file to a timestamp map to see if it's been modified since."
+  [timestamp-map file]
+  (> (.lastModified file) (get timestamp-map file 0)))
+
+(defn- newer-sources [timestamp-map files]
+  (filter (partial modified? timestamp-map) files))
+
+(defn- newer-namespace-decls [timestamp-map files]
+  (remove nil? (map read-file-ns-decl (newer-sources timestamp-map files))))
 
 (defn- add-to-dep-graph [dep-graph namespace-decls]
   (reduce (fn [g decl]
@@ -55,21 +65,21 @@
   namespaces that need to be reloaded, based on file modification
   timestamps and the graph of namespace dependencies."
   ([dirs]
-     (ns-tracker dirs (System/currentTimeMillis)))
-  ([dirs initial-timestamp]
-     {:pre [(integer? initial-timestamp)]}
+     (ns-tracker dirs (current-timestamp-map (normalize-dirs dirs))))
+  ([dirs initial-timestamp-map]
+     {:pre [(map? initial-timestamp-map)]}
      (let [dirs (normalize-dirs dirs)
-           timestamp (atom initial-timestamp)
-           init-decls (newer-namespace-decls dirs 0)
+           timestamp-map (atom initial-timestamp-map)
+           init-decls (newer-namespace-decls {} (keys @timestamp-map))
            dependency-graph (atom (update-dependency-graph (graph) init-decls))]
        (fn []
-         (let [then @timestamp
-               now  (System/currentTimeMillis)
-               new-decls (newer-namespace-decls dirs then)]
+         (let [then @timestamp-map
+               now (current-timestamp-map (normalize-dirs dirs))
+               new-decls (newer-namespace-decls then (keys now))]
            (when (seq new-decls)
              (let [new-names (map second new-decls)
                    affected-names
                    (affected-namespaces new-names @dependency-graph)]
-               (reset! timestamp now)
+               (reset! timestamp-map now)
                (swap! dependency-graph update-dependency-graph new-decls)
                affected-names)))))))


### PR DESCRIPTION
Instead of comparing all file modification dates against a fixed time,
a map is kept to determine which have changed. Fixes #3.
