### PR TITLE
Replace contains? on LazySeq with some

### DIFF
--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -35,12 +35,12 @@
 (defn depends?
   "True if x is directly or transitively dependent on y."
   [graph x y]
-  (contains? (dependencies graph x) y))
+  (some #(= y %) (dependencies graph x)))
 
 (defn dependent
   "True if y is a dependent of x."
   [graph x y]
-  (contains? (dependents graph x) y))
+  (some #(= y %) (dependents graph x)))
 
 (defn- add-relationship [graph key x y]
   (update-in graph [key x] union #{y}))


### PR DESCRIPTION
contains? now throws an exception when called with a LazySeq. Replace contains? with some to check for dependencies.

This fixes issue #8.
