### PR TITLE
Detect changes in namespaces split over several files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject ns-tracker "0.2.0"
   :description "Keep track of which namespaces have been modified"
-  :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.clojure/tools.namespace "0.1.3"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
+                 [org.clojure/tools.namespace "0.2.2"]
                  [org.clojure/java.classpath "0.2.0"]]
   :profiles
   {:dev {:dependencies [[commons-io "1.4"]]}

--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -35,12 +35,12 @@
 (defn depends?
   "True if x is directly or transitively dependent on y."
   [graph x y]
-  (contains? (dependencies graph x) y))
+  (some #(= y %) (dependencies graph x)))
 
 (defn dependent
   "True if y is a dependent of x."
   [graph x y]
-  (contains? (dependents graph x) y))
+  (some #(= y %) (dependents graph x)))
 
 (defn- add-relationship [graph key x y]
   (update-in graph [key x] union #{y}))


### PR DESCRIPTION
Addresses open issues #1, #7, #8, and #9
- will now re-load namespaces if a source file that is explicitly loaded changes.
  This will only work if the first non-comment form of the 'helper' or
  'extension' source file is an (in-ns) form. It will not look for any
  subsequent in-ns forms in the file. This is the same idiomatic usage of
  load/in-ns that is found in clojure/core.
  - newer-namespace-decls returns a list of ns-decls (as before) but also
    a set of namespace names (symbols) that have been affected.
-  avoid calling .fileModifed twice for each source file
- replace contains? (as in
  https://github.com/ahjones/ns-tracker/commit/164822959e47c2d8d2540aa063140f2a9609bfbc)
-  use tools.namespace 0.2.2 (similarly to
  https://github.com/jakemcc/ns-tracker/commit/6884b4cd8ad6e8547ce5ed6f54e3f257c547d215)
- use clojure 1.3.0 (required by tools.namespace)
