### PR TITLE
Ignore dependencies for namespaces that use/require themselves.

### DIFF
--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -46,17 +46,18 @@
   (update-in graph [key x] union #{y}))
 
 (defn depend
-  "Adds to the dependency graph that x depends on deps.  Forbids
-  circular dependencies."
+  "Adds to the dependency graph that x depends on deps. Forbids
+  circular and self-referential dependencies."
   ([graph x] graph)
   ([graph x dep]
-     {:pre [(not (depends? graph dep x))]}
+     (assert (not (depends? graph dep x)) "circular dependency")
+     (assert (not (= x dep)) "self-referential dependency")
      (-> graph
-	 (add-relationship :dependencies x dep)
-	 (add-relationship :dependents dep x)))
+         (add-relationship :dependencies x dep)
+         (add-relationship :dependents dep x)))
   ([graph x dep & more]
      (reduce (fn [g d] (depend g x d))
-	     graph (cons dep more))))
+             graph (cons dep more))))
 
 (defn- remove-from-map [amap x]
   (reduce (fn [m [k vs]]

--- a/test/ns_tracker/test/core.clj
+++ b/test/ns_tracker/test/core.clj
@@ -73,5 +73,16 @@
         (spit (file "tmp/example/util.clj") '(ns example.util))
         (is (= (modified-namespaces) '(example.util example.core)))))
 
+    (testing "circular dependencies throw an AssertionError"
+      (spit (file "tmp/example/ns1.clj") '(ns example.ns1 (:require [example.ns2])))
+      (spit (file "tmp/example/ns2.clj") '(ns example.ns2 (:require [example.ns1])))
+      (Thread/sleep 1000)
+      (is (thrown? AssertionError (ns-tracker [(file "tmp")]))))
+
+    (testing "self-dependencies throw an AssertionError"
+      (spit (file "tmp/example/ns1.clj") '(ns example.ns1 (:require [example.ns1])))
+      (Thread/sleep 1000)
+      (is (thrown? AssertionError (ns-tracker [(file "tmp")]))))
+    
     (finally
      (FileUtils/deleteDirectory (file "tmp")))))


### PR DESCRIPTION
This commit prevents a StackOverflowError that will occur when computing
transitive dependencies for a namespace that depends on itself.

Clojure currently allows namespace declarations that use/require itself:

``` clojure
(ns x
  (:require [x]))
```

ns-tracker adds these as dependencies in its graph but blows up with a StackOverflowError when calculating transitive dependencies. 

This proposed fix simply ignores such dependencies, much like the clojure `ns` macro does.

Having self-referential namespaces is obviously wrong, but since the problem is not caught by the `ns` macro it is very hard to debug when it blows up in ns-tracker.
