### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: clojure
-script: lein with-profile default:+1.6:+1.7 test
+script: lein with-profile default:+1.6:+1.7:+1.8:+1.9 test

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
 (defproject ns-tracker "0.3.0"
   :description "Keep track of which namespaces have been modified"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/tools.namespace "0.2.10"]
-                 [org.clojure/java.classpath "0.2.2"]]
+                 [org.clojure/tools.namespace "0.2.11"]
+                 [org.clojure/java.classpath "0.2.3"]]
   :profiles
-  {:dev {:dependencies [[commons-io "1.4"]]}
+  {:dev {:dependencies [[commons-io "2.5"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7 {:dependencies [[org.clojure/clojure "1.7.0-beta2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,6 @@
   :profiles
   {:dev {:dependencies [[commons-io "2.5"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-   :1.7 {:dependencies [[org.clojure/clojure "1.7.0-beta2"]]}})
+   :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+   :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]}})

--- a/test/ns_tracker/test/core.clj
+++ b/test/ns_tracker/test/core.clj
@@ -47,7 +47,22 @@
         (Thread/sleep 1000)
         (spit (file "tmp/example/a.clj") '(ns example.a))
         (is (= (modified-namespaces)
-               '(example.a example.b example.c example.d)))))
+               '(example.a example.b example.c example.d))))
+
+      (when-not (neg? (compare (clojure-version) "1.7.0"))
+        (testing "modified cljc files are reloaded (Clojure 1.7+)"
+          (Thread/sleep 1000)
+          (spit (file "tmp/example/a_cljc.cljc") '(ns example.a-cljc))
+          (is (= (modified-namespaces) '(example.a-cljc)))
+          (is (empty? (modified-namespaces)))
+          (Thread/sleep 1000)
+          (spit (file "tmp/example/b_cljc.cljc") 
+                "(ns example.b-cljc (:require #?(:clj [example.a-cljc] :cljs [example.a-cljc])))")
+          (is (= (modified-namespaces) '(example.b-cljc)))
+          (Thread/sleep 1000)
+          (spit (file "tmp/example/a_cljc.cljc") '(ns example.a-cljc (:require clojure.set)))        
+          (is (= (modified-namespaces) '(example.a-cljc example.b-cljc)))
+          (is (empty? (modified-namespaces))))))
 
     (testing "directories can be supplied as strings"
       (let [modified-namespaces (ns-tracker ["tmp"])]


### PR DESCRIPTION
Added test case for a .cljc file change and reader conditional. Reproduces #20 and we can see that after upgrading tools.namespace to 0.2.11 the test passes.

Added profiles for Clojure 1.8.0 and 1.9.0-alpha13.

`lein ancient` reported that commons-io and org.clojure/java.classpath were out of date too, so I upgraded them as well.