### PR TITLE
Track a namespace's dependencies on non-Clojure files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ the fly:
 This can be placed in a background thread, or triggered by some user
 request.
 
+### Declaring Dependencies to Static Resources
+
+Some Clojure libraries, such as
+[HugSQL](https://www.hugsql.org/#using-def-db-fns), define functions in
+a namespace based on the content of a static resource file. ns-tracker
+is able to reload such a namespace when the resource file is modified
+with the help of a bit metadata.
+
+You will need to declare the resources under the
+`:ns-tracker/resource-deps` key in the namespace's metadata:
+
+    (ns example.db
+      {:ns-tracker/resource-deps ["sql/queries.sql"]}
+      (:require example.utils))    
+
+The resource path needs to be relative to one of the source directories
+which you gave as a parameter to the `ns-tracker.core/ns-tracker`
+function.
+
 ## License
 
 Copyright © 2016 James Reeves, Stuart Sierra

--- a/src/ns_tracker/core.clj
+++ b/src/ns_tracker/core.clj
@@ -1,21 +1,25 @@
 (ns ns-tracker.core
   "Keeps track of which namespaces have changed and need to be reloaded."
-  (:import java.io.PushbackReader)
-  (:require [clojure.java.io :as io])
-  (:use [ns-tracker.dependency :only (graph seq-union depend dependents remove-key)]
-        [ns-tracker.nsdeps :only (deps-from-ns-decl)]
-        [ns-tracker.parse :only (read-in-ns-decl)]
-        [clojure.java.io :only (file)]
-        [clojure.tools.namespace.find :only (find-clojure-sources-in-dir)]
-        [clojure.tools.namespace.parse :only (read-ns-decl)]))
+  (:import java.io.PushbackReader
+           java.io.File)
+  (:require [clojure.java.io :as io]
+            [clojure.set :refer [union]]
+            [clojure.tools.namespace.file :refer [clojure-file?]]
+            [clojure.tools.namespace.parse :refer [read-ns-decl]]
+            [ns-tracker.dependency :refer [graph seq-union depend dependents remove-key]]
+            [ns-tracker.nsdeps :refer [deps-from-ns-decl]]
+            [ns-tracker.parse :refer [read-in-ns-decl]]))
 
 (defn- file? [f]
   (instance? java.io.File f))
 
+(defn- find-files-in-dir [dir]
+  (filter #(.isFile ^File %) (file-seq dir)))
+
 (defn- find-sources
   [dirs]
   {:pre [(every? file? dirs)]}
-  (mapcat find-clojure-sources-in-dir dirs))
+  (mapcat find-files-in-dir dirs))
 
 (defn- current-timestamp-map
   "Get the current modified timestamp map for all sources"
@@ -34,32 +38,34 @@
   (with-open [rdr (PushbackReader. (io/reader file))]
     (func rdr)))
 
-(defn- newer-namespace-decls [then now]
+(defn- newer-namespace-decls [then now dependency-graph]
   (loop [new-decls []
          new-names #{}
          files (newer-sources then now)]
     (if-let [file (first files)]
-      (if-let [ns-decl (read-file file read-ns-decl)]
-        (recur (conj new-decls ns-decl) (conj new-names (second ns-decl)) (rest files))
-        (if-let [in-ns-decl (read-file file read-in-ns-decl)]
-          (recur new-decls (conj new-names (second in-ns-decl)) (rest files))
-          (recur new-decls new-names (rest files))))
+      (if (clojure-file? file)
+        (if-let [ns-decl (read-file file read-ns-decl)]
+          (recur (conj new-decls ns-decl) (conj new-names (second ns-decl)) (rest files))
+          (if-let [in-ns-decl (read-file file read-in-ns-decl)]
+            (recur new-decls (conj new-names (second in-ns-decl)) (rest files))
+            (recur new-decls new-names (rest files))))
+        (recur new-decls (union new-names (set (get-in dependency-graph [:dependents file]))) (rest files)))
       [new-decls new-names])))
 
-(defn- add-to-dep-graph [dep-graph namespace-decls]
+(defn- add-to-dep-graph [dep-graph namespace-decls dirs]
   (reduce (fn [g decl]
 	    (let [nn (second decl)
-		  deps (deps-from-ns-decl decl)]
+		  deps (deps-from-ns-decl decl dirs)]
 	      (apply depend g nn deps)))
 	  dep-graph namespace-decls))
 
 (defn- remove-from-dep-graph [dep-graph new-decls]
   (apply remove-key dep-graph (map second new-decls)))
 
-(defn- update-dependency-graph [dep-graph new-decls]
+(defn- update-dependency-graph [dep-graph new-decls dirs]
   (-> dep-graph
       (remove-from-dep-graph new-decls)
-      (add-to-dep-graph new-decls)))
+      (add-to-dep-graph new-decls dirs)))
 
 (defn- affected-namespaces [changed-namespaces old-dependency-graph]
   (apply seq-union changed-namespaces
@@ -68,13 +74,13 @@
 
 (defn- make-file [f]
   {:pre [(or (string? f) (file? f))]}
-  (if (file? f) f (file f)))
+  (if (file? f) f (io/file f)))
 
 (defn- normalize-dirs [dirs]
   {:pre [(or (string? dirs) (sequential? dirs))]}
   (cond
-   (string? dirs)     [(file dirs)]
-   (sequential? dirs) (map make-file dirs)))
+    (string? dirs) [(io/file dirs)]
+    (sequential? dirs) (map make-file dirs)))
 
 (defn ns-tracker
   "Returns a no-arg function which, when called, returns a set of
@@ -86,14 +92,17 @@
      {:pre [(map? initial-timestamp-map)]}
      (let [dirs (normalize-dirs dirs)
            timestamp-map (atom initial-timestamp-map)
-           [init-decls init-names] (newer-namespace-decls {} @timestamp-map)
-           dependency-graph (atom (update-dependency-graph (graph) init-decls))]
+           [init-decls init-names] (newer-namespace-decls {} @timestamp-map {})
+           dependency-graph (atom (update-dependency-graph (graph) init-decls
+                                                           dirs))]
        (fn []
          (let [then @timestamp-map
                now (current-timestamp-map (normalize-dirs dirs))
-               [new-decls new-names] (newer-namespace-decls then now)]
+               [new-decls new-names] (newer-namespace-decls then now
+                                                            @dependency-graph)]
            (when (seq new-names)
-             (let [affected-names (affected-namespaces new-names @dependency-graph)]
+             (let [affected-names (affected-namespaces new-names
+                                                       @dependency-graph)]
                (reset! timestamp-map now)
-               (swap! dependency-graph update-dependency-graph new-decls)
+               (swap! dependency-graph update-dependency-graph new-decls dirs)
                affected-names)))))))

--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -1,6 +1,6 @@
 (ns ns-tracker.dependency
   "Bidirectional graphs of dependencies and dependent objects."
-  (:use [clojure.set :only (union)]))
+  (:require [clojure.set :refer [union]]))
 
 (defn graph "Returns a new, empty, dependency graph." []
   {:dependencies {}

--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -18,8 +18,8 @@
   at (get m x)"
   [m x]
   (reduce (fn [s k]
-	    (seq-union s (transitive m k)))
-	  (get m x) (get m x)))
+            (seq-union s (transitive m k)))
+          (get m x) (get m x)))
 
 (defn dependencies
   "Returns the set of all things x depends on, directly or transitively."
@@ -50,38 +50,38 @@
   circular and self-referential dependencies."
   ([graph x] graph)
   ([graph x dep]
-     (assert (not (depends? graph dep x)) "circular dependency")
-     (assert (not (= x dep)) "self-referential dependency")
-     (-> graph
-         (add-relationship :dependencies x dep)
-         (add-relationship :dependents dep x)))
+   (assert (not (depends? graph dep x)) "circular dependency")
+   (assert (not (= x dep)) "self-referential dependency")
+   (-> graph
+       (add-relationship :dependencies x dep)
+       (add-relationship :dependents dep x)))
   ([graph x dep & more]
-     (reduce (fn [g d] (depend g x d))
-             graph (cons dep more))))
+   (reduce (fn [g d] (depend g x d))
+           graph (cons dep more))))
 
 (defn- remove-from-map [amap x]
   (reduce (fn [m [k vs]]
-	    (assoc m k (disj vs x)))
-	  {} (dissoc amap x)))
+            (assoc m k (disj vs x)))
+          {} (dissoc amap x)))
 
 (defn remove-all
   "Removes all references to x in the dependency graph."
   ([graph] graph)
   ([graph x]
-     (assoc graph
-       :dependencies (remove-from-map (:dependencies graph) x)
-       :dependents (remove-from-map (:dependents graph) x)))
+   (assoc graph
+     :dependencies (remove-from-map (:dependencies graph) x)
+     :dependents (remove-from-map (:dependents graph) x)))
   ([graph x & more]
-     (reduce remove-all
-	     graph (cons x more))))
+   (reduce remove-all
+           graph (cons x more))))
 
 (defn remove-key
   "Removes the key x from the dependency graph without removing x as a
   depedency of other keys."
   ([graph] graph)
   ([graph x]
-     (assoc graph
-       :dependencies (dissoc (:dependencies graph) x)))
+   (assoc graph
+     :dependencies (dissoc (:dependencies graph) x)))
   ([graph x & more]
-     (reduce remove-key
-	     graph (cons x more))))
+   (reduce remove-key
+           graph (cons x more))))

--- a/src/ns_tracker/nsdeps.clj
+++ b/src/ns_tracker/nsdeps.clj
@@ -1,6 +1,7 @@
 (ns ns-tracker.nsdeps
   "Parsing namespace declarations for dependency information."
-  (:use [clojure.set :only (union)]))
+  (:import java.io.File)
+  (:require [clojure.set :refer [union]]))
 
 (defn- deps-from-libspec [prefix form]
   (cond (list? form) (deps-from-libspec prefix (vec form))
@@ -21,8 +22,44 @@
 	     (contains? #{:use :require} (first form)))
     (apply union (map #(deps-from-libspec nil %) (rest form)))))
 
+(defn- find-resource [path dirs]
+  (->> (map #(File. ^File % ^String path) dirs)
+       (filter #(.isFile ^File %))
+       first))
+
+(defn- print-warnings-for-missing-resources [namespace resources dirs]
+  (doseq [resource (->> resources
+                        (filter #(nil? (second %)))
+                        (map first))]
+    (binding [*out* *err*]
+      (let [dirs (vec (map #(.getPath ^File %) dirs))]
+        (println (str "ns-tracker: Unable to track dependency from namespace "
+                      namespace " to resource \"" resource "\". The resource "
+                      "was not found in directories " dirs "."))))))
+
+(defn- ns-attr-map [[_ _ docstring? attr-map?]]
+  (cond
+    (map? docstring?) docstring?
+    (map? attr-map?) attr-map?))
+
+(defn- ns-metadata [[_ name :as decl]]
+  (merge (meta name)
+         (ns-attr-map decl)))
+
+(defn- deps-from-ns-metadata [[_ name :as decl] dirs]
+  (let [deps (:ns-tracker/resource-deps (ns-metadata decl))
+        resources (for [dep deps]
+                    [dep (find-resource dep dirs)])]
+    (print-warnings-for-missing-resources name resources dirs)
+    (set (remove nil? (map second resources)))))
+
 (defn deps-from-ns-decl
-  "Given a (quoted) ns declaration, returns a set of symbols naming
-  the dependencies of that namespace.  Handles :use and :require clauses."
-  [decl]
-  (apply union (map deps-from-ns-form decl)))
+  "Given a (quoted) ns declaration and list of source directories, returns
+  a set of symbols and files naming the dependencies of that namespace.
+  Namespace dependencies are symbols and resource dependencies are java.io.File
+  instances. Handles :use and :require clauses, and :ns-tracker/resource-deps
+  metadata."
+  [decl dirs]
+  (union
+    (deps-from-ns-metadata decl dirs)
+    (apply union (map deps-from-ns-form decl))))

--- a/src/ns_tracker/nsdeps.clj
+++ b/src/ns_tracker/nsdeps.clj
@@ -9,17 +9,18 @@
                                 (not (keyword? (second form))))
                          (let [prefix (and prefix (str prefix "."))]
                            (->> (rest form)
-                                (map #(deps-from-libspec (symbol (str prefix (first form))) %))
+                                (map #(deps-from-libspec
+                                        (symbol (str prefix (first form))) %))
                                 (apply union)))
                          (deps-from-libspec prefix (first form)))
-	(symbol? form) #{(symbol (str (when prefix (str prefix ".")) form))}
-	(keyword? form) #{}
-	:else (throw (IllegalArgumentException.
-		      (pr-str "Unparsable namespace form:" form)))))
+        (symbol? form) #{(symbol (str (when prefix (str prefix ".")) form))}
+        (keyword? form) #{}
+        :else (throw (IllegalArgumentException.
+                       (pr-str "Unparsable namespace form:" form)))))
 
 (defn- deps-from-ns-form [form]
   (when (and (list? form)
-	     (contains? #{:use :require} (first form)))
+             (contains? #{:use :require} (first form)))
     (apply union (map #(deps-from-libspec nil %) (rest form)))))
 
 (defn- find-resource [path dirs]

--- a/src/ns_tracker/parse.clj
+++ b/src/ns_tracker/parse.clj
@@ -1,5 +1,5 @@
 (ns ns-tracker.parse
-  (:use [clojure.tools.namespace.parse :only (comment?)]))
+  (:require [clojure.tools.namespace.parse :refer [comment?]]))
 
 (defn in-ns-decl?
   "Returns true if form is a (in-ns ...) declaration."

--- a/src/ns_tracker/parse.clj
+++ b/src/ns_tracker/parse.clj
@@ -16,7 +16,7 @@
     (loop []
       (let [form (doto (read rdr) str)]
         (cond
-         (in-ns-decl? form) form
-         (comment? form) (recur)
-         :else nil)))
-       (catch Exception e nil)))
+          (in-ns-decl? form) form
+          (comment? form) (recur)
+          :else nil)))
+    (catch Exception e nil)))

--- a/test/ns_tracker/core_test.clj
+++ b/test/ns_tracker/core_test.clj
@@ -1,12 +1,13 @@
 (ns ns-tracker.core-test
   (:import org.apache.commons.io.FileUtils)
-  (:use ns-tracker.core
-        clojure.test
-        [clojure.java.io :only (file)]))
+  (:require [ns-tracker.core :refer :all]
+            [clojure.test :refer :all]
+            [clojure.java.io :refer [file]]))
 
 (deftest test-ns-tracker
   (.mkdirs (file "tmp/example"))
   (.mkdirs (file "tmp/example/internal"))
+  (.mkdirs (file "tmp/sql"))
   (try
     (let [modified-namespaces (ns-tracker [(file "tmp")])]
       (testing "modified files are reloaded"
@@ -24,6 +25,16 @@
         (Thread/sleep 1000)
         (spit (file "tmp/example/util.clj") '(ns example.util))
         (is (= (modified-namespaces) '(example.util example.core))))
+
+      (testing "dependent files of static resources are reloaded"
+        (Thread/sleep 1000)
+        (spit (file "tmp/sql/queries.sql") "select 1")
+        (spit (file "tmp/example/db.clj")
+              "(ns ^{:ns-tracker/resource-deps [\"sql/queries.sql\"]} example.db)")
+        (modified-namespaces)
+        (Thread/sleep 1000)
+        (spit (file "tmp/sql/queries.sql") "select 1")
+        (is (= (modified-namespaces) '(example.db))))
 
       (testing "can handle in-ns forms"
         (Thread/sleep 1000)

--- a/test/ns_tracker/core_test.clj
+++ b/test/ns_tracker/core_test.clj
@@ -15,7 +15,7 @@
         (spit (file "tmp/example/core.clj") '(ns example.core))
         (is (= (modified-namespaces) '(example.core)))
         (is (empty? (modified-namespaces))))
-      
+
       (testing "dependant files are reloaded"
         (Thread/sleep 1000)
         (spit (file "tmp/example/util.clj") '(ns example.util))
@@ -67,11 +67,11 @@
           (is (= (modified-namespaces) '(example.a-cljc)))
           (is (empty? (modified-namespaces)))
           (Thread/sleep 1000)
-          (spit (file "tmp/example/b_cljc.cljc") 
+          (spit (file "tmp/example/b_cljc.cljc")
                 "(ns example.b-cljc (:require #?(:clj [example.a-cljc] :cljs [example.a-cljc])))")
           (is (= (modified-namespaces) '(example.b-cljc)))
           (Thread/sleep 1000)
-          (spit (file "tmp/example/a_cljc.cljc") '(ns example.a-cljc (:require clojure.set)))        
+          (spit (file "tmp/example/a_cljc.cljc") '(ns example.a-cljc (:require clojure.set)))
           (is (= (modified-namespaces) '(example.a-cljc example.b-cljc)))
           (is (empty? (modified-namespaces))))))
 
@@ -135,4 +135,4 @@
       (is (thrown? AssertionError (ns-tracker [(file "tmp")]))))
 
     (finally
-     (FileUtils/deleteDirectory (file "tmp")))))
+      (FileUtils/deleteDirectory (file "tmp")))))

--- a/test/ns_tracker/nsdeps_test.clj
+++ b/test/ns_tracker/nsdeps_test.clj
@@ -1,0 +1,71 @@
+(ns ns-tracker.nsdeps-test
+  (:require [clojure.java.io :as io]
+            [clojure.string :refer [trim-newline]]
+            [clojure.test :refer :all]
+            [ns-tracker.nsdeps :refer :all])
+  (:import (org.apache.commons.io FileUtils)
+           (java.io StringWriter)))
+
+(defmacro with-err-str [& body]
+  `(let [s# (new StringWriter)]
+     (binding [*err* s#]
+       ~@body
+       (str s#))))
+
+(deftest test-deps-from-ns-decl
+  (let [tmp-dir (io/file "tmp")]
+    (try
+      (.mkdirs (io/file "tmp/sql"))
+      (spit (io/file "tmp/sql/foo.sql") "")
+
+      (testing "resource-deps metadata, reader macro"
+        (is (= #{(io/file "tmp/sql/foo.sql")}
+               (deps-from-ns-decl
+                 '(ns ^{:ns-tracker/resource-deps ["sql/foo.sql"]} example.db)
+                 [tmp-dir]))))
+
+      (testing "resource-deps metadata, attr-map"
+        (is (= #{(io/file "tmp/sql/foo.sql")}
+               (deps-from-ns-decl
+                 '(ns example.db
+                    {:ns-tracker/resource-deps ["sql/foo.sql"]})
+                 [tmp-dir]))))
+
+      (testing "resource-deps metadata, docstring & attr-map"
+        (is (= #{(io/file "tmp/sql/foo.sql")}
+               (deps-from-ns-decl
+                 '(ns example.db
+                    "docstring"
+                    {:ns-tracker/resource-deps ["sql/foo.sql"]})
+                 [tmp-dir]))))
+
+      (testing "metadata from reader macro and attr-map is merged"
+        (is (= #{(io/file "tmp/sql/foo.sql")}
+               (deps-from-ns-decl
+                 '(ns ^{:ns-tracker/resource-deps ["sql/foo.sql"]} example.db
+                    {})
+                 [tmp-dir])))
+        (is (= #{(io/file "tmp/sql/foo.sql")}
+               (deps-from-ns-decl
+                 '(ns ^{} example.db
+                    {:ns-tracker/resource-deps ["sql/foo.sql"]})
+                 [tmp-dir])))
+        (is (= #{(io/file "tmp/sql/foo.sql")}
+               (deps-from-ns-decl
+                 '(ns ^{:ns-tracker/resource-deps ["this-will-be-overridden"]} example.db
+                    {:ns-tracker/resource-deps ["sql/foo.sql"]})
+                 [tmp-dir]))))
+
+      (testing "prints a warning to stderr if the resource is not found"
+        (let [result (atom nil)
+              stderr (with-err-str
+                       (reset! result
+                               (deps-from-ns-decl
+                                 '(ns ^{:ns-tracker/resource-deps ["sql/bar.sql"]} example.db)
+                                 [tmp-dir])))]
+          (is (= #{} @result))
+          (is (= "ns-tracker: Unable to track dependency from namespace example.db to resource \"sql/bar.sql\". The resource was not found in directories [\"tmp\"]."
+                 (trim-newline stderr)))))
+
+      (finally
+        (FileUtils/deleteDirectory tmp-dir)))))


### PR DESCRIPTION
This PR implements issue #23. 

If you add `:resource-deps` metadata to a namespace declaration and list there all the static resources which the namespace depends on, then that namespace will be reloaded whenever one of those resources is changed.

An example usage with [Luminus conman](https://github.com/luminus-framework/conman) would look like this:

```clj
(ns ^{:resource-deps ["sql/queries.sql"]} rems.db.core
  (:require [conman.core :as conman]))
...
(conman/bind-connection *db* "sql/queries.sql")
```

Additionally Ring's `wrap-reload` may need to be configured to find the resources directory:

```clj
(-> handler
    (wrap-reload {:dirs ["src" "resources"]}))
```

This PR is also available as a published binary; add the following dependency and exclude the original ns-tracker.

```clj
[org.clojars.luontola/ns-tracker "0.3.1-patch1"]
[ring/ring-devel "1.6.3" :exclusions [ns-tracker]]
```