### PR TITLE
Faster transitive implementation

### DIFF
--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -17,9 +17,12 @@
   "Recursively expands the set of dependency relationships starting
   at (get m x)"
   [m x]
-  (reduce (fn [s k]
-            (seq-union s (transitive m k)))
-          (get m x) (get m x)))
+  (loop [acc [], deps (get m x)]
+    (if-let [new-deps (seq (distinct (remove (set acc) deps)))]
+      (recur
+       (into acc new-deps)
+       (mapcat (partial get m) new-deps))
+      acc)))
 
 (defn dependencies
   "Returns the set of all things x depends on, directly or transitively."


### PR DESCRIPTION
Hey @weavejester, 

I've noticed that [`lein-ring`](https://github.com/weavejester/lein-ring) starts really slow for larger projects (for example it usually takes 15-20 minutes to launch Metabase via `lein ring server`, compared to ~1 with `lein run`).

I did some profiling and determined 98% of the launch time was spent in `ns-tracker.dependency/transitive`, mainly because it recursively calls `transitive` on everything before finally removing duplicates in `seq-union`. I changed this to an implementation that avoids recursive calls for dependencies that have already been dealt with, which has pretty dramatic performance improvements.

To test this I captured a real-world graph of ~200 namespaces from Metabase during launch and compared the old and new implementations. The namespaces graph and code I used to compare implementations is [here](https://gist.github.com/camsaul/908cb7c51f716be5a74c76825050c7d5) if you'd like to see for yourself. When testing locally, the new implementation is around 1000x faster: 

<table>
    <thead>
        <tr>
            <th>Implementation</th>
            <th>Time</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>Old</td>
            <td>873.714 ms</td>
        </tr>
        <tr>
            <td>New</td>
            <td>0.754 ms</td>
        </tr>
    </tbody>
</table>

I can also confirm that it has fixed the slow launch time issue I was running into.

The order of results in the new implementation are consistently breadth-first whereas results in the old implementation are mostly breadth-first but, not consistently so. I put an example comparison between the orders returned by the implementations [here](https://gist.github.com/camsaul/908cb7c51f716be5a74c76825050c7d5#file-old_order_vs_new_order-clj). As far as I can tell the slight order differences has no effect on the reloading code that relies on it.