### PR TITLE
Improve self-referential error message to include offending namespace

### DIFF
--- a/src/ns_tracker/dependency.clj
+++ b/src/ns_tracker/dependency.clj
@@ -54,7 +54,7 @@
   ([graph x] graph)
   ([graph x dep]
    (assert (not (depends? graph dep x)) "circular dependency")
-   (assert (not (= x dep)) "self-referential dependency")
+   (assert (not (= x dep)) (str "self-referential dependency " dep))
    (-> graph
        (add-relationship :dependencies x dep)
        (add-relationship :dependents dep x)))

--- a/test/ns_tracker/core_test.clj
+++ b/test/ns_tracker/core_test.clj
@@ -132,7 +132,9 @@
     (testing "self-dependencies throw an AssertionError"
       (spit (file "tmp/example/ns1.clj") '(ns example.ns1 (:require [example.ns1])))
       (Thread/sleep 1000)
-      (is (thrown? AssertionError (ns-tracker [(file "tmp")]))))
+      (is (thrown-with-msg? AssertionError
+                            #"self-referential dependency example.ns1"
+                            (ns-tracker [(file "tmp")]))))
 
     (finally
       (FileUtils/deleteDirectory (file "tmp")))))


### PR DESCRIPTION
This way it is much easier to fix such an errors in a large codebase