### PR TITLE
Support `:as-alias` from Clojure 1.11

### DIFF
--- a/src/ns_tracker/nsdeps.clj
+++ b/src/ns_tracker/nsdeps.clj
@@ -12,7 +12,9 @@
                                 (map #(deps-from-libspec
                                         (symbol (str prefix (first form))) %))
                                 (apply union)))
-                         (deps-from-libspec prefix (first form)))
+                         (if (= (second form) :as-alias)
+                           #{}
+                           (deps-from-libspec prefix (first form))))
         (symbol? form) #{(symbol (str (when prefix (str prefix ".")) form))}
         (keyword? form) #{}
         :else (throw (IllegalArgumentException.

--- a/test/ns_tracker/nsdeps_test.clj
+++ b/test/ns_tracker/nsdeps_test.clj
@@ -67,5 +67,12 @@
           (is (= "ns-tracker: Unable to track dependency from namespace example.db to resource \"sql/bar.sql\". The resource was not found in directories [\"tmp\"]."
                  (trim-newline stderr)))))
 
+      (testing "ignores `:as-alias` require"
+        (is (= #{'example.foo}
+               (deps-from-ns-decl
+                '(ns example.db (:require [example.foo :as foo]
+                                          [example.bar :as-alias bar]))
+                [tmp-dir]))))
+
       (finally
         (FileUtils/deleteDirectory tmp-dir)))))


### PR DESCRIPTION
This adds support to Clojure 1.11's `:as-alias` as outlined in https://clojure.atlassian.net/browse/CLJ-2123 and implemented in https://github.com/clojure/clojure/commit/f96eef2.